### PR TITLE
Add shebang to fra

### DIFF
--- a/fra
+++ b/fra
@@ -1,3 +1,4 @@
+#!/usr/bin/env php
 <?php
 
 /*


### PR DESCRIPTION
Shebang helps in determining the correct program to execute by the system when file is called without the php cli keyword in front.

So, instead of calling
```bash
php fra ...
```

this can be simplified on Unix alike systems with

```bash
fra ...
```

And many editors, including GitHub, add syntax highlighting to the file.